### PR TITLE
Device properties added to jwt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,3 @@
-## [1.0.0] - 26/03/2021
+## [1.0.2] - 18/06/2021
+
+* deviceProperties added to Appbooster.initialize.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Mobile framework for Appbooster platform.
       appsFlyerId: "${YOUR_APPS_FLYER_UID}" // optional
       amplitudeUserId: "${YOUR_AMPLITUDE_USER_ID}" // optional, if Amplitude integration is needed
       defaults: {"${TEST_1_KEY}": "${TEST_1_DEFAULT_VALUE}", "${TEST_2_KEY}": "${TEST_2_DEFAULT_VALUE}"},
+      deviceProperties: {"installedAt": "2021-05-20T09:55:05.000+03:00"}, // optional, additional information about device
     );
 ```
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -32,6 +32,9 @@ class _MyHomePageState extends State<MyHomePage> {
     "flutter_test": "green",
     "test_experiment": "value_1"
   };
+  static const _deviceProperties = {
+    "installedAt": "2021-05-20T09:55:05.000+03:00",
+  };
   bool _debugOnShake = false;
   bool _showProgress = false;
 
@@ -41,6 +44,7 @@ class _MyHomePageState extends State<MyHomePage> {
       appId: "16897",
       sdkToken: "E44A1C2E762B41A691494FAB045993DF",
       defaults: _experimentsDefaults,
+      deviceProperties: _deviceProperties,
     );
     if (!mounted) return;
     setState(() => _showProgress = false);
@@ -110,6 +114,13 @@ class _MyHomePageState extends State<MyHomePage> {
               padding: const EdgeInsets.only(bottom: 8.0),
               child: Text(
                 "Defaults:\n${_experimentsDefaults.toString()}",
+                style: theme.textTheme.subtitle1,
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8.0),
+              child: Text(
+                "deviceProperties:\n${_deviceProperties.toString()}",
                 style: theme.textTheme.subtitle1,
               ),
             ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.2"
   async:
     dependency: transitive
     description:

--- a/lib/appbooster_sdk_flutter.dart
+++ b/lib/appbooster_sdk_flutter.dart
@@ -35,6 +35,7 @@ class Appbooster {
     String appsFlyerId,
     String amplitudeUserId,
     @required Map<String, String> defaults,
+    Map<String, dynamic> deviceProperties,
   }) async {
     assert(_instance == null, 'Appbooster SDK is already initialized.');
 
@@ -51,6 +52,7 @@ class Appbooster {
       deviceId: deviceId,
       appsFlyerId: appsFlyerId,
       amplitudeUserId: amplitudeUserId,
+      deviceProperties: deviceProperties,
     );
     _instance = instance;
   }

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -13,6 +13,7 @@ class _Client {
     String deviceId,
     String appsFlyerId,
     String amplitudeUserId,
+    Map<String, dynamic> deviceProperties,
   }) {
     assert(sdkToken != null);
     assert(appId != null);
@@ -22,6 +23,7 @@ class _Client {
       amplitudeUserId: amplitudeUserId,
       appsFlyerId: appsFlyerId,
       deviceId: deviceId,
+      deviceProperties: deviceProperties,
     );
     _headers = {
       'Authorization': 'Bearer $jwt',

--- a/lib/jwt.dart
+++ b/lib/jwt.dart
@@ -5,12 +5,14 @@ String _generateJwt({
   String deviceId,
   String appsFlyerId,
   String amplitudeUserId,
+  Map<String, dynamic> deviceProperties,
 }) {
   final jwt = JWT({
     'deviceId': deviceId,
     if (appsFlyerId?.isNotEmpty ?? false) 'appsFlyerId': appsFlyerId,
-    if (amplitudeUserId?.isNotEmpty ?? false)
-      'amplitudeId': amplitudeUserId,
+    if (amplitudeUserId?.isNotEmpty ?? false) 'amplitudeId': amplitudeUserId,
+    if (deviceProperties?.isNotEmpty ?? false)
+      'deviceProperties': deviceProperties,
   });
   return jwt.sign(SecretKey(sdkToken), algorithm: JWTAlgorithm.HS256);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: appbooster_sdk_flutter
 description: Mobile framework for Appbooster platform.
-version: 1.0.1
+version: 1.0.2
 maintainer: Appbooster (https://github.com/appbooster)
 homepage: https://appbooster.com
 


### PR DESCRIPTION
#### :tophat: Что? Зачем?
Пробрасываем хэш deviceProperties на сервер в jwt при инициализации SDK.
Протестировать можно через тестовое приложение: в jwt будет отправлено `{ "installedAt": "2021-05-20T09:55:05.000+03:00" }`, тестовый sdkToken: E44A1C2E762B41A691494FAB045993DF
[app-release.apk.zip](https://github.com/appbooster/appbooster_sdk_flutter/files/6672351/app-release.apk.zip)

